### PR TITLE
Fixed syslog pruning when dbFetchRow() returns array (#10850)

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -71,7 +71,7 @@ if ($options['f'] === 'syslog') {
         if (is_numeric($syslog_purge)) {
             $rows = (int)dbFetchCell('SELECT MIN(seq) FROM syslog');
             while (true) {
-                $limit = dbFetchRow('SELECT seq FROM syslog WHERE seq >= ? ORDER BY seq LIMIT 1000,1', array($rows));
+                $limit = dbFetchCell('SELECT seq FROM syslog WHERE seq >= ? ORDER BY seq LIMIT 1000,1', array($rows));
                 if (empty($limit)) {
                     break;
                 }


### PR DESCRIPTION
If dbFetchRow() returns an array, dbDelete() won't do its work pruning the syslog table and we'll drop out of the block via break.  This if statement will take the value return inside the array and replace $limit with that value.  This way, dbDelete() can successfully prune the syslog table.

dbFetchCell() can return an array that won't work when fed to dbDelete().  This keeps that from occurring so the syslog table can be pruned.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
